### PR TITLE
Fix initial load display issue for text-only tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "gh-pages": "^5.0.0",
-        "i": "^0.3.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-feather": "^2.0.10",
@@ -9948,14 +9947,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
-    },
-    "node_modules/i": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
-      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -31603,11 +31594,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
-    },
-    "i": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
-      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -58,6 +58,7 @@ export const App = () => {
                 color={tileColors[index] || tile.color} // Use the shuffled color if available
                 shuffleColors={shuffleColors} // Pass the shuffleColors function
                 tileSize={tileSizes[index]}
+                flipped={tile.flipped}
               />
             ))}
         </Content>

--- a/src/data.json
+++ b/src/data.json
@@ -4,25 +4,29 @@
       "tileName": "Welcome!",
       "content": "Namaste",
       "isSquare": true,
-      "color": "#603F83FF"
+      "color": "#603F83FF",
+      "flipped": true
     },
     {
       "tileName": "Click me!",
       "content": "Click on Tejas twice!",
       "isSquare": false,
-      "color": "#C7D3D4FF"
+      "color": "#C7D3D4FF",
+      "flipped": true
     },
     {
       "tileName": "Who am I?",
       "content": "Software Enginner coding for passion & engineering",
       "isSquare": true,
-      "color": "#00539CFF"
+      "color": "#00539CFF",
+      "flipped": true
     },
     {
       "tileName": "Skills",
       "content": "Python, Java, [Vertica, MySQL](SQL), MongoDB, Spring boot, Pytest",
       "isSquare": false,
-      "color": "#EEA47FFF"
+      "color": "#EEA47FFF",
+      "flipped": true
     },
     {
       "tileName": "My Github",
@@ -33,7 +37,8 @@
         "iconAlt": "Icon"
       },
       "isSquare": false,
-      "color": "#4183C4"
+      "color": "#4183C4",
+      "flipped": false
     },
     {
       "tileName": "Located at",
@@ -44,13 +49,15 @@
         "iconAlt": "Icon"
       },
       "isSquare": false,
-      "color": "#DB4437"
+      "color": "#DB4437",
+      "flipped": false
     },
     {
       "tileName": "Color Shuffle",
       "content": "Color Shuffle",
       "isSquare": true,
-      "color": "#FFFFFF"
+      "color": "#FFFFFF",
+      "flipped": false
     },
     {
       "tileName": "LinkedIn",
@@ -61,7 +68,8 @@
         "iconAlt": "Icon"
       },
       "isSquare": false,
-      "color": "#0e76a8"
+      "color": "#0e76a8",
+      "flipped": false
     },
     {
       "tileName": "Rock Playlist",
@@ -72,19 +80,22 @@
         "iconAlt": "Icon"
       },
       "isSquare": true,
-      "color": "#1ED760"
+      "color": "#1ED760",
+      "flipped": false
     },
     {
       "tileName": "About this site!",
       "content": "Made with \u2764  by me, chatgpt, stackoverflow",
       "isSquare": true,
-      "color": "#FC766AFF"
+      "color": "#FC766AFF",
+      "flipped": true
     },
     {
       "tileName": "Currently I'm",
       "content": "Software Engineer @ Sandvine Technologies",
       "isSquare": true,
-      "color": "#5B84B1FF"
+      "color": "#5B84B1FF",
+      "flipped": true
     }
   ]
 }

--- a/src/data.json
+++ b/src/data.json
@@ -57,7 +57,7 @@
       "content": "Color Shuffle",
       "isSquare": true,
       "color": "#FFFFFF",
-      "flipped": false
+      "flipped": true
     },
     {
       "tileName": "LinkedIn",

--- a/src/tiles/Tiles.js
+++ b/src/tiles/Tiles.js
@@ -15,9 +15,10 @@ export const Tiles = ({
   isSquare,
   color,
   shuffleColors,
+  flipped,
 }) => {
   const isDarkMode = useContext(ThemeContext);
-  const [isFlipped, setIsFlipped] = useState(false);
+  const [isFlipped, setIsFlipped] = useState(flipped);
   const [isAnimating, setIsAnimating] = useState(false);
   const [tileSize, setTileSize] = useState(`${getRandomSize()}px`);
   const [shouldOpenLink, setShouldOpenLink] = useState(false);
@@ -74,7 +75,7 @@ export const Tiles = ({
         </IconContainer>
       );
     } else {
-      return <TileContent>{tileName}</TileContent>;
+      return <TileContent>{content}</TileContent>;
     }
   };
 
@@ -85,7 +86,7 @@ export const Tiles = ({
       tileSize={tileSize}
       onClick={handleClick}
     >
-      <TileName>{isFlipped ? content : renderContent()}</TileName>
+      <TileName>{isFlipped ? tileName : renderContent()}</TileName>
     </Tile>
   );
 };

--- a/src/tiles/Tiles.js
+++ b/src/tiles/Tiles.js
@@ -74,7 +74,7 @@ export const Tiles = ({
         </IconContainer>
       );
     } else {
-      return <TileContent>{content}</TileContent>;
+      return <TileContent>{tileName}</TileContent>;
     }
   };
 
@@ -85,7 +85,7 @@ export const Tiles = ({
       tileSize={tileSize}
       onClick={handleClick}
     >
-      <TileName>{isFlipped ? tileName : renderContent()}</TileName>
+      <TileName>{isFlipped ? content : renderContent()}</TileName>
     </Tile>
   );
 };

--- a/src/tiles/Tiles.js
+++ b/src/tiles/Tiles.js
@@ -47,7 +47,8 @@ export const Tiles = ({
       }
     }, 300);
 
-    setIsFlipped(!isFlipped);
+    if(tileName!="Color Shuffle")
+      setIsFlipped(!isFlipped);
   };
 
   useEffect(() => {


### PR DESCRIPTION
 ## ISSUE-10: Fix initial load display issue for text-only tiles
Fixes #10 
## Changes
Changed the content displayed at the time of load to the `tileName` and the flip content to `content`.

## Current output

**On loading**

![image](https://github.com/tejas-k3/tejas-kothari-portfolio/assets/72661784/8896c079-49b7-4ff0-9b49-e773d04e96b0)

**After flipping**

![image](https://github.com/tejas-k3/tejas-kothari-portfolio/assets/72661784/19a27923-ab36-43a7-8860-804fd0d2243e)
